### PR TITLE
Update openfisca-uk usage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test [Python 3.7, 3.8, 3.9]
+name: Build and test [Python 3.7, 3.8]
 
 on: [push, pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8]
 
     steps:
       - name: Checkout

--- a/og_uk_calibrate/get_micro_data.py
+++ b/og_uk_calibrate/get_micro_data.py
@@ -71,7 +71,9 @@ def get_calculator_output(baseline, year, reform=None, data=None):
         - sim.df(["earned_income"]).values.squeeze(),
         "market_income": market_income,
         "total_tax_liab": sim.calc("income_tax").values,
-        "payroll_tax_liab": sim.calc("national_insurance").values,  # is this in OpenFisca-UK?
+        "payroll_tax_liab": sim.calc(
+            "national_insurance"
+        ).values,  # is this in OpenFisca-UK?
         "etr": sim.calc("tax").values / market_income,
         "year": year * np.ones(length),
         "weight": sim.calc("person_weight").values,

--- a/og_uk_calibrate/tests/test_get_micro_data.py
+++ b/og_uk_calibrate/tests/test_get_micro_data.py
@@ -34,7 +34,7 @@ def test_frs():
 
     # create a parametric reform
     def lower_pa(parameters):
-        parameters.taxes.income_tax.allowances.personal_allowance.amount.update(
+        parameters.tax.income_tax.allowances.personal_allowance.amount.update(
             period="2020", value=10000
         )
         return parameters


### PR DESCRIPTION
OpenFisca-UK just had a considerable update merged, which uses a new interface (to make loading data from different surveys and years much easier, as well as performance improvements). I've adjusted the code here that accesses openfisca-uk to use the new API (largely just syntax changes). A few comments/questions on the pre-existing code, the semantics of which I haven't changed:
- sim.calc is equivalent to sim.df([one_variable]).values.squeeze(), but more concise
- the UK has [National Insurance](https://en.wikipedia.org/wiki/Payroll_tax#United_Kingdom) - is this close enough to US payroll tax?
- self-employment: we use trading profits to calculate tax, but income drawn from the business for gross income (to be consistent with official disposable income definitions). Not sure if this was already known, just thought I'd double check
```python
# Compute marginal tax rates (can only do on earned income now)
mtr = sim.mtr().values
```
- Happy to say this is no longer the case! You'll want to use sim.deriv(target, wrt=source, group_limit=lim), where target is e.g. household net income, source is e.g. dividend_income, and group_limit is e.g. 2 (we calculate derivatives for individual adults, but preserving independence within households), and just negate it to get the format needed.