### PR TITLE
Fix microsimulation bugs

### DIFF
--- a/og_uk_calibrate/get_micro_data.py
+++ b/og_uk_calibrate/get_micro_data.py
@@ -66,8 +66,8 @@ def get_calculator_output(baseline, year, reform=None, data=None):
     # Put MTRs, income, tax liability, and other variables in dict
     length = len(sim.df(["person_weight"]))
     tax_dict = {
-        "mtr_labinc": mtr,
-        "mtr_capinc": mtr,
+        "mtr_labinc": 1 - sim.deriv("household_net_income", wrt="employment_income").fillna(1).values,
+        "mtr_capinc": 1 - sim.deriv("household_net_income", wrt="savings_interest_income").fillna(1).values,
         "age": sim.calc("age").values,
         "total_labinc": sim.calc("earned_income").values,
         "total_capinc": market_income
@@ -75,7 +75,7 @@ def get_calculator_output(baseline, year, reform=None, data=None):
         "market_income": market_income,
         "total_tax_liab": sim.calc("income_tax").values,
         "payroll_tax_liab": sim.calc("national_insurance").values,
-        "etr": sim.calc("tax").values / market_income,
+        "etr": sim.calc("net_income").values / market_income,
         "year": year * np.ones(length),
         "weight": sim.calc("person_weight").values,
     }

--- a/og_uk_calibrate/get_micro_data.py
+++ b/og_uk_calibrate/get_micro_data.py
@@ -58,10 +58,9 @@ def get_calculator_output(baseline, year, reform=None, data=None):
 
     # define market income - taking expanded_income and excluding gov't
     # transfer benefits
-    market_income = sim.calc("gross_income").values
+    market_income = sim.calc("gross_income").values - sim.calc("benefits").values
 
     # Compute marginal tax rates (can only do on earned income now)
-    mtr = sim.mtr().values
 
     # Put MTRs, income, tax liability, and other variables in dict
     length = len(sim.df(["person_weight"]))

--- a/og_uk_calibrate/get_micro_data.py
+++ b/og_uk_calibrate/get_micro_data.py
@@ -75,7 +75,7 @@ def get_calculator_output(baseline, year, reform=None, data=None):
         "market_income": market_income,
         "total_tax_liab": sim.calc("income_tax").values,
         "payroll_tax_liab": sim.calc("national_insurance").values,
-        "etr": sim.calc("net_income").values / market_income,
+        "etr": 1 - sim.calc("net_income").values / market_income,
         "year": year * np.ones(length),
         "weight": sim.calc("person_weight").values,
     }

--- a/og_uk_calibrate/get_micro_data.py
+++ b/og_uk_calibrate/get_micro_data.py
@@ -58,15 +58,23 @@ def get_calculator_output(baseline, year, reform=None, data=None):
 
     # define market income - taking expanded_income and excluding gov't
     # transfer benefits
-    market_income = sim.calc("gross_income").values - sim.calc("benefits").values
+    market_income = (
+        sim.calc("gross_income").values - sim.calc("benefits").values
+    )
 
     # Compute marginal tax rates (can only do on earned income now)
 
     # Put MTRs, income, tax liability, and other variables in dict
     length = len(sim.df(["person_weight"]))
     tax_dict = {
-        "mtr_labinc": 1 - sim.deriv("household_net_income", wrt="employment_income").fillna(1).values,
-        "mtr_capinc": 1 - sim.deriv("household_net_income", wrt="savings_interest_income").fillna(1).values,
+        "mtr_labinc": 1
+        - sim.deriv("household_net_income", wrt="employment_income")
+        .fillna(1)
+        .values,
+        "mtr_capinc": 1
+        - sim.deriv("household_net_income", wrt="savings_interest_income")
+        .fillna(1)
+        .values,
         "age": sim.calc("age").values,
         "total_labinc": sim.calc("earned_income").values,
         "total_capinc": market_income


### PR DESCRIPTION
@jdebacker @jpycroft @rickecon @MaxGhenis 

Just noticed a few things that could be changed on the openfisca-uk side:
- We can calculate the MTR for capital income - @jdebacker I've done this by technically calculating the MTR for savings income, but dividends are taxed differently in the UK so I imagine there's a correct way to do this?
- ETR should actually use net income rather than tax - this takes into account benefit receipts.
- Market income (from the comment I'm assuming) shouldn't include benefits, but gross income does, so this subtracts benefits from the gross income result.