### PR TITLE
Limit to Python 3.7

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: Build and test [Python 3.7, 3.8]
+name: Build and test [Python 3.7]
 
 on: [push, pull_request]
 
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7]
 
     steps:
       - name: Checkout

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
 - dask==2.30.0
 - dask-core==2.30.0
 - distributed==2.30.1
+- paramtools>=0.15.0
 - pip
 - pytest>=6.0
 - pytest-pep8

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: oguk-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.7.7
+- python<=3.7.11
 - dask==2.30.0
 - dask-core==2.30.0
 - distributed==2.30.1

--- a/examples/run_oguk.py
+++ b/examples/run_oguk.py
@@ -11,7 +11,7 @@ from ogcore.execute import runner
 from ogcore.utils import safe_read_pickle
 
 # Set start year and last year
-START_YEAR = 2020
+START_YEAR = 2018
 from ogcore.parameters import Specifications
 
 
@@ -81,7 +81,7 @@ def main():
     # Create a parametric reform for OpenFisca-UK
     def lower_pa(parameters):
         parameters.tax.income_tax.allowances.personal_allowance.amount.update(
-            period="2020", value=10000
+            period="2018", value=10000
         )
         return parameters
 

--- a/oguk/get_micro_data.py
+++ b/oguk/get_micro_data.py
@@ -16,7 +16,7 @@ import warnings
 warnings.filterwarnings("ignore")
 
 CUR_PATH = os.path.split(os.path.abspath(__file__))[0]
-DATA_LAST_YEAR = 2020  # this is the last year data are extrapolated for
+DATA_LAST_YEAR = 2018  # this is the last year data are extrapolated for
 
 
 def get_calculator_output(baseline, year, reform=None, data=None):


### PR DESCRIPTION
This PR changes the environment to ensure that Python 3.7 is used.  It also removes testing on Python 3.8.

The OpenFisca platform is not engineered to work beyond Python 3.7 at the moment. 

Addresses Issue #28.