### PR TITLE
update style file url

### DIFF
--- a/oguk/calibrate.py
+++ b/oguk/calibrate.py
@@ -7,8 +7,8 @@ import pkg_resources
 import matplotlib.pyplot as plt
 
 style_file = os.path.join(
-    "https://github.com/PSLmodels/OG-Core/blob/master/ogcore/"
-    + "OGcorePlots.mplstyle"
+    "https://raw.githubusercontent.com/PSLmodels/OG-Core/master/ogcore"
+    + "/OGcorePlots.mplstyle"
 )
 plt.style.use(style_file)
 
@@ -27,7 +27,7 @@ class Calibration:
         tax_func_path=None,
         iit_reform=None,
         guid="",
-        data="cps",
+        data="frs",
         client=None,
         num_workers=1,
     ):

--- a/oguk/calibrate.py
+++ b/oguk/calibrate.py
@@ -4,13 +4,7 @@ import os
 import numpy as np
 from ogcore.utils import safe_read_pickle, mkdirs
 import pkg_resources
-import matplotlib.pyplot as plt
 
-style_file = os.path.join(
-    "https://raw.githubusercontent.com/PSLmodels/OG-Core/master/ogcore"
-    + "/OGcorePlots.mplstyle"
-)
-plt.style.use(style_file)
 
 CUR_PATH = os.path.split(os.path.abspath(__file__))[0]
 


### PR DESCRIPTION
This PR updates the URL for the matplotlib style file.  I *think* this will stop the warnings that appeared when trying to look for a style file at the previous URL.  Note that this URL is referenced because, to my knowledge, a style file can't be part of a python package (e.g., OG-Core).

At some point, we may want each country model to have it's own style file (e.g., with country-specific colors).  But this should help in the meantime.