### PR TITLE
Add UK corporate tax rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0).
 
+## [0.1.2] - 2022-07-29
+
+### Fixed
+
+* UK corporate tax rate schedule added.
+
 ## [0.1.1] - 2022-07-19
 
 ### Changed

--- a/oguk/oguk_default_parameters.json
+++ b/oguk/oguk_default_parameters.json
@@ -140,7 +140,7 @@
     "initial_debt_ratio": 0.78,
     "r_gov_scale": 1.0,
     "r_gov_shift": 0.02,
-    "cit_rate": [[0.21]],
+    "cit_rate": [[0.19], [0.25]],
     "c_corp_share_of_assets": 0.55,
     "adjustment_factor_for_cit_receipts": [0.30909090909090914],
     "tau_c": [[0.0]],

--- a/oguk/tests/test_get_micro_data.py
+++ b/oguk/tests/test_get_micro_data.py
@@ -32,7 +32,7 @@ def test_frs():
 
     # create a parametric reform
     def lower_pa(parameters):
-        parameters.tax.income_tax.allowances.personal_allowance.amount.update(
+        parameters.gov.hmrc.income_tax.allowances.personal_allowance.amount.update(
             period="year:2022:10", value=10000
         )
         return parameters

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
 with open("README.md") as f:
     longdesc = f.read()
 
-version = "0.1.1"
+version = "0.1.2"
 
 config = {
     "description": "OG-UK",


### PR DESCRIPTION
This PR replaces the default (US) corporate tax rate with the UK rates. The UK tax rate is [currently 19%, but scheduled to rise to 25% from FY23 onwards](https://www.gov.uk/government/publications/corporation-tax-charge-and-rates-from-1-april-2022-and-small-profits-rate-and-marginal-relief-from-1-april-2023/corporation-tax-charge-and-rates-from-1-april-2022-and-small-profits-rate-and-marginal-relief-from-1-april-2023).