### PR TITLE
change default initial interest rate to allow base solution

### DIFF
--- a/oguk/oguk_default_parameters.json
+++ b/oguk/oguk_default_parameters.json
@@ -1713,7 +1713,7 @@
     "maxiter": 250,
     "mindist_SS": 1e-09,
     "mindist_TPI": 1e-05,
-    "initial_guess_r_SS": 0.03,
+    "initial_guess_r_SS": 0.035,
     "initial_guess_TR_SS": 0.02,
     "initial_guess_factor_SS": 29415,
     "omega": [


### PR DESCRIPTION
I had been unable to solve the SS or TPI with the current default values (working with Windows OS and 4 processors).

@rickecon suggested trying a different starting interest rate: 0.03 --> 0.035 (line 1716 in oguk/oguk_default_parameters)
and now my SS and TPI solve!

We suggest that the default "initial_guess_r_SS" be changed to 0.035.
