### PR TITLE
Depend on policyengine[uk] instead of flooring policyengine-uk separately

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,13 @@ dependencies = [
     # branch), breaking calibrate(); cap until oguk migrates to the
     # income-heterogeneity API.
     "ogcore>=0.15.6,<0.18",
-    "policyengine>=4.22",
-    "policyengine-uk>=2.89.2",
+    # Depend on the umbrella package's uk extra rather than flooring
+    # policyengine-uk separately: `uk_latest` reports the version from
+    # policyengine's bundled manifest, not the installed package, so an
+    # independent floor cannot raise the model version actually simulated
+    # against -- it only decouples the two and downgrades the mismatch to
+    # a UserWarning. The extra keeps them in lockstep.
+    "policyengine[uk]>=5.0,<6",
     "requests>=2.31",
     "rich>=13.0",
     "openpyxl>=3.1",


### PR DESCRIPTION
## Why

The standalone `policyengine-uk>=2.89.2` floor looks like it controls the model version. It doesn't.

`uk_latest` — passed as `tax_benefit_model_version` in `_get_micro_data` (`api.py:378`) — reads the version from **policyengine's bundled manifest**, not from the installed `policyengine-uk`. So the independent floor cannot raise the version OG-UK simulates against; it only lets the installed rules drift away from the manifest.

With `policyengine==5.0.4` and `policyengine-uk==2.93.1`, both admitted today, pip resolves happily and every import works — but:

```
UserWarning: Installed policyengine-uk version (2.93.1) does not match the
bundled policyengine.py manifest (2.90.2). ... dataset compatibility is not guaranteed.

>>> uk_latest.version
'2.90.2'
```

`policyengine-core` drifts the same way (3.31.1 installed vs the 3.30.1 the extra pins).

## What changes after merging

A fresh unlocked install can no longer land mismatched rules against the manifest — the extra pins them together. `policyengine` is also capped below 6, where before `>=4.22` silently admitted the 4.x→5.x major bump.

**Nothing moves in practice:** `uv.lock` is unchanged. It already resolved to 5.0.4 / 3.30.1 / 2.90.2, so CI has been testing this combination all along and only the declaration was loose.

## Change

```toml
-    "policyengine>=4.22",
-    "policyengine-uk>=2.89.2",
+    "policyengine[uk]>=5.0,<6",
```

Nothing in `oguk/` imports `policyengine_uk` directly, so the country package is an implementation detail of `policyengine`.

## Evidence

Fresh install of `policyengine[uk]>=5.0,<6`:

```
installed pe-uk  : 2.90.2
uk_latest.version: 2.90.2
mismatch warnings: NONE
all imports OK
```

**Not verified:** a full calibration run against 5.x — that needs microdata I don't have locally and CI doesn't exercise a solve. Since `uv.lock` is unchanged this shouldn't move any resolved version, but a maintainer confirming one `calibrate()` before merge would be worth it.

Fixes #74.
